### PR TITLE
no-wastewater-flows indicator with language support, html order, missing tag

### DIFF
--- a/html_js/css/index.css
+++ b/html_js/css/index.css
@@ -940,3 +940,7 @@ body:fullscreen #fullscreen-btn {
 body:-webkit-full-screen #fullscreen-btn {
   display: none;
 }
+
+.hidden {
+  display: none;
+}

--- a/html_js/index.html
+++ b/html_js/index.html
@@ -258,7 +258,7 @@
 
       <div id="sidebar-header">
         <div><a href="https://www.sandiegocounty.gov/" target="_blank"><img src="img/logoCOSD.png"></a></div>
-        <div id="sidebar-title"><h1 data-i18n="sidebar.title">Tijuana River Valley Sewage Crisis Environmental Dashboard</span></h1></div>
+        <div id="sidebar-title"><h1 data-i18n="sidebar.title">Tijuana River Valley Sewage Crisis Environmental Dashboard</h1></div>
         <div><a href="https://resilientshield.ucsd.edu/" target="_blank"><img src="img/ResilientLogo.png"></a></div>
       </div>
 
@@ -633,23 +633,23 @@
             <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.wastewater.p1.link.text" data-i18n-href="sidebar.cards.wastewater.p1.link.url">More Info</a>
 
           </p>
+          <p>
+            <span data-i18n="sidebar.cards.wastewater.p2.body">and here</span>
+            <br>
+            <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.wastewater.p2.link.text" data-i18n-href="sidebar.cards.wastewater.p2.link.url">Wastewater Spills</a>
+
+          </p>
 
           <div id="wastewater-data" class="card-data">
             <span data-i18n="sidebar.cards.wastewater.tableLabel">Complaints in the last 7 days</span>
             <table>
               <tbody>
                 <tr>
-
+                  <p id="no-wastewater-flows" class="hidden" data-i18n="sidebar.cards.wastewater.noFlows">No Wastewater Flows</p>
                 </tr>
               </tbody>
             </table>
           </div>
-<p>
-  <span data-i18n="sidebar.cards.wastewater.p2.body">and here</span>
-  <br>
-  <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.wastewater.p2.link.text" data-i18n-href="sidebar.cards.wastewater.p2.link.url">Wastewater Spills</a>
-
-</p>
           <div class="card-footer">
 
             <span data-i18n="sidebar.cards.wastewater.footer.text"></span>

--- a/html_js/js/app.js
+++ b/html_js/js/app.js
@@ -395,9 +395,7 @@ function renderWastewaterFlows(data) {
     console.log("[app.js] (Spills) Added spill entry:", { startTime, endTime, volume, notes }, jsonDiv.lastChild);
   }
   if (mostRecentData.length === 0 ){
-    jsonDiv.innerHTML += '<p>No Wastewater Flows</p>'
-
-    jsonDiv.appendChild(rowElm);
+    document.querySelector("#no-wastewater-flows").classList.remove("hidden");
     console.log("[app.js] (Spills) No data found.");
   }
   const cardFooter = document.querySelector(

--- a/html_js/locales/en.json
+++ b/html_js/locales/en.json
@@ -190,6 +190,7 @@
         "tableLabel": "Flows in the last {{spill_days}} days",
         "dailyCount_one": "{{count}} flow",
         "dailyCount_other": "{{count}} flows",
+        "noFlows": "No Wastewater Flows",
         "footer": {
           "text": "Last Updated on {{date}}",
           "link": {

--- a/html_js/locales/es.json
+++ b/html_js/locales/es.json
@@ -191,6 +191,7 @@
         "tableLabel": "Flujos en los últimos {{spill_days}} días",
         "dailyCount_one": "{{count}} flujo",
         "dailyCount_other": "{{count}} flujos",
+        "noFlows": "No hay flujos de aguas residuales",
         "footer": {
           "text": "Última actualización el {{date}}",
           "link": {


### PR DESCRIPTION
- Moved the "No Wastewater Flows" <p> out of javascript and into the html and added an i18n entry for it so it works in english and spanish
- Moved wastewater "more details" up above the list of flows with the rest of the text
- Deleted a </span> that wasn't closing anything