### PR TITLE
Displayed wastewater and complaint data shows n-days from last update

### DIFF
--- a/html_js/js/app.js
+++ b/html_js/js/app.js
@@ -122,8 +122,9 @@ function renderOdorComplaints(geoData) {
 
   const now = new Date();
   const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const mostRecentSampleTime = new Date(now.getTime() - (window.complaint_days) * 24 * 60 * 60 * 1000);
-  const secondMostRecentSampleTime = new Date(now.getTime() - (window.complaint_days*2) * 24 * 60 * 60 * 1000);
+  const latestDate = dayjs(geoData.lastUpdated).toDate();
+  const mostRecentSampleTime = new Date(latestDate.getTime() - (window.complaint_days) * 24 * 60 * 60 * 1000);
+  const secondMostRecentSampleTime = new Date(latestDate.getTime() - (window.complaint_days*2) * 24 * 60 * 60 * 1000);
 
   console.log(
     "[app.js] Current date:",
@@ -255,7 +256,6 @@ function renderOdorComplaints(geoData) {
     "#odor-complaints-card .card-footer"
   );
   if (cardFooter && mostRecentData.length > 0) {
-    latestDate = dayjs(geoData.lastUpdated).toDate();
     console.log("[app.js] Updating odor complaints footer with latest date.", geoData.lastUpdated, "converted to", latestDate);
     const span = cardFooter.querySelector("span");
     const formattedDate = formatDateTime(latestDate, {
@@ -280,8 +280,9 @@ function renderWastewaterFlows(data) {
 
   const now = new Date();
   const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const mostRecentSampleTime = new Date(now.getTime() - (window.spill_days) * 24 * 60 * 60 * 1000);
-  const secondMostRecentSampleTime = new Date(now.getTime() - (window.spill_days*2) * 24 * 60 * 60 * 1000);
+  const latestDate = dayjs(data.lastUpdated).toDate();
+  const mostRecentSampleTime = new Date(latestDate.getTime() - (window.spill_days) * 24 * 60 * 60 * 1000);
+  const secondMostRecentSampleTime = new Date(latestDate.getTime() - (window.spill_days*2) * 24 * 60 * 60 * 1000);
 
   console.log(
     "[app.js] (Spills) Current date:",
@@ -404,7 +405,6 @@ function renderWastewaterFlows(data) {
     "#wastewater-card .card-footer"
   );
   if (cardFooter) {
-    latestDate = dayjs(data.lastUpdated).toDate();
     console.log("[app.js] (Spills) Updating wastewater footer with latest date.", data.lastUpdated, "converted to", latestDate);
     const span = cardFooter.querySelector("span");
     const formattedDate = formatDateTime(latestDate, {


### PR DESCRIPTION
Previously was showing data from the last n-days from today (eg. if capturing 2 weeks, will filter all data outside of 14 days ago to today, if the last data update was 3 days ago, that means we're only really grabbing 11 days of data)
Now showing n-days from the last update time. So if the last data update was 3 days ago, data captured is from 17 days ago to 3 days ago (total of 14 days).