### PR TITLE
Drinking Water advisory card, map layer and filter pill

### DIFF
--- a/html_js/css/index.css
+++ b/html_js/css/index.css
@@ -602,6 +602,126 @@ button.button.map-control-button.button {
   height: var(--p-half);
 }
 
+/* Drinking water advisories */
+#water-advisory-count {
+  font-weight: normal;
+}
+
+#water-advisory-data-overview table {
+  border-spacing: 0;
+}
+
+/* Advisory type names run long ("Main break / boil order"), so these cells wrap
+   rather than clipping the way the fixed single-line data tables do. */
+#water-advisory-data tr td {
+  white-space: normal;
+  vertical-align: top;
+}
+
+#water-advisory-data tr td:first-child {
+  width: 42%;
+}
+
+#water-advisory-data tr td:last-child {
+  width: 58%;
+}
+
+/* Inline so wrapped text flows under the clock icon instead of starting a new
+   block below it. The first column keeps its inline-block status dot. */
+#water-advisory-data tr td:last-child span {
+  display: inline;
+}
+
+/* The advisory message needs to wrap, unlike the fixed single-line data rows. */
+#water-advisory-data tr td.water-advisory-message {
+  width: 100%;
+  white-space: normal;
+  font-weight: normal;
+  font-size: 0.8rem;
+  color: var(--grey);
+  padding-left: calc(var(--icon) + var(--p-half));
+}
+
+#water-advisory-data tr td.water-advisory-message * {
+  display: inline;
+}
+
+#water-advisory-data tr td.water-advisory-message a {
+  margin-left: var(--p-half);
+  white-space: nowrap;
+}
+
+.water-advisory-alert {
+  border-radius: var(--border-radius);
+  border-left: 4px solid var(--grey);
+  padding: var(--p1) var(--p2);
+  background: rgba(128, 128, 128, 0.12);
+}
+
+.water-advisory-alert.emergency {
+  border-left-color: #ed1c25;
+  background: rgba(237, 28, 37, 0.12);
+}
+
+.water-advisory-alert.general {
+  border-left-color: #f9a028;
+  background: rgba(249, 160, 40, 0.14);
+}
+
+.water-advisory-alert-header {
+  display: flex;
+  align-items: center;
+  gap: var(--p1);
+  font-weight: bold;
+}
+
+.water-advisory-alert.emergency .water-advisory-alert-header {
+  color: #ed1c25;
+}
+
+.water-advisory-alert.general .water-advisory-alert-header {
+  color: #b26a10;
+}
+
+.water-advisory-alert-body {
+  padding-top: var(--p-half);
+  font-size: 0.85rem;
+}
+
+.water-advisory-alert-body:empty {
+  display: none;
+}
+
+.water-advisory-coverage {
+  font-size: 0.8rem;
+  color: var(--grey);
+}
+
+.legend-swatch {
+  width: var(--icon);
+  height: var(--icon);
+  border-radius: 2px;
+  display: inline-block;
+  flex: none;
+}
+
+.legend-swatch.water-advisory-emergency {
+  background: rgba(237, 28, 37, 0.25);
+  border: 1px solid #ed1c25;
+}
+
+.legend-swatch.water-advisory-general {
+  background: rgba(249, 160, 40, 0.25);
+  border: 1px solid #f9a028;
+}
+
+/* Advisory notices are long, so let the popup text wrap and cap its height. */
+.water-advisory-tooltip .water-advisory-note {
+  white-space: normal;
+  max-height: 9rem;
+  overflow-y: auto;
+}
+
 .text-card {
 }
 

--- a/html_js/css/index.css
+++ b/html_js/css/index.css
@@ -692,6 +692,52 @@ button.button.map-control-button.button {
   display: none;
 }
 
+/* Demonstration mode (?wateradvisory=). Deliberately loud and unlike the real
+   alert styling, so an example advisory can never pass for a genuine one. */
+.water-advisory-demo {
+  display: flex;
+  align-items: center;
+  gap: var(--p1);
+  border: 2px dashed #6b21a8;
+  border-radius: var(--border-radius);
+  padding: var(--p1) var(--p2);
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(107, 33, 168, 0.08),
+    rgba(107, 33, 168, 0.08) 10px,
+    rgba(107, 33, 168, 0.16) 10px,
+    rgba(107, 33, 168, 0.16) 20px
+  );
+  color: #6b21a8;
+  font-weight: bold;
+  font-size: 0.8rem;
+}
+
+.water-advisory-demo i {
+  flex: none;
+}
+
+.water-advisory-demo-tag {
+  margin-left: var(--p-half);
+  padding: 0 var(--p-half);
+  border: 1px solid #6b21a8;
+  border-radius: 2px;
+  color: #6b21a8;
+  font-size: 0.7rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.water-advisory-tooltip .water-advisory-demo-line {
+  border: 1px dashed #6b21a8;
+  border-radius: 2px;
+  padding: 2px var(--p-half);
+  color: #6b21a8;
+  font-weight: bold;
+  white-space: normal;
+}
+
 .water-advisory-coverage {
   font-size: 0.8rem;
   color: var(--grey);

--- a/html_js/index.html
+++ b/html_js/index.html
@@ -86,6 +86,10 @@
     // Get the value of the "name" parameter
     const spill_days = Number(params.get('spill')?? 30);
     window.spill_days = spill_days;
+    // Shows a clearly-labelled example drinking water advisory for demonstrations.
+    // ?wateradvisory=demo (boil water), =emergency, =general. Off unless set.
+    window.water_advisory_demo = params.get('wateradvisory') ?? '';
+    console.log('water advisory demo', window.water_advisory_demo)
     window.spill_timeframe = {
       numDays: spill_days,
       latestDate: undefined,
@@ -591,64 +595,6 @@
           </div>
         </div>
 
-        <!-- Card: Drinking Water Advisories (tap water) -->
-        <div id="water-advisory-card" class="card shadow expandable" onclick="selectCard('Drinking Water Advisories')">
-          <div class="card-header always-expand">
-            <i class="bi bi-droplet-half"></i>
-            <h3 class="card-title" data-i18n="sidebar.cards.waterAdvisory.title">Drinking Water (Tap Water)</h3>
-            <button class="expand-btn"><i class="bi bi-chevron-down"></i></button>
-          </div>
-
-          <div id="water-advisory-data-overview" class="card-data always-expand">
-            <table>
-              <tbody>
-                <tr>
-                  <td>
-                    <span class="indicator low"></span>
-                    <span id="water-advisory-count" data-i18n="sidebar.cards.waterAdvisory.overview.none">No active advisories</span>
-                    <br><span class="sublabel trend-flat" data-i18n="sidebar.cards.waterAdvisory.overview.scope">California American Water service area</span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-
-          <!-- Shown only when an advisory is active in the region -->
-          <div id="water-advisory-alert" class="water-advisory-alert always-expand" hidden>
-            <div class="water-advisory-alert-header">
-              <i class="bi bi-exclamation-triangle-fill"></i>
-              <span class="water-advisory-alert-title"></span>
-            </div>
-            <p class="water-advisory-alert-body"></p>
-          </div>
-
-          <p data-i18n="sidebar.cards.waterAdvisory.p1">
-            Tap water delivered to homes in the region is treated and tested to meet state and federal drinking water standards. Sewage flows in the Tijuana River Valley affect beach and river water, not the treated water supplied to your tap.
-          </p>
-
-          <p>
-            <span data-i18n="sidebar.cards.waterAdvisory.p2.body">Your water utility issues an advisory when a main break, emergency repair, or planned work may affect your service or water quality. Check who supplies your water and look up current notices here:</span>
-            <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.waterAdvisory.p2.link.text" data-i18n-href="sidebar.cards.waterAdvisory.p2.link.url">California American Water Customer Advisories</a>
-          </p>
-
-          <p class="water-advisory-coverage" data-i18n="sidebar.cards.waterAdvisory.coverage">
-            Advisories shown here come from California American Water only. Other utilities serve parts of this region, so check with your own provider if you are unsure.
-          </p>
-
-          <div id="water-advisory-data" class="card-data" hidden>
-            <span data-i18n="sidebar.cards.waterAdvisory.tableLabel">Current advisories in the region</span>
-            <table>
-              <tbody>
-              </tbody>
-            </table>
-          </div>
-
-          <div class="card-footer">
-            <span data-i18n="sidebar.cards.waterAdvisory.footer.text"></span>
-            <a target="_blank" href="https://example.com" data-i18n="sidebar.cards.waterAdvisory.footer.link.text" data-i18n-href="sidebar.cards.waterAdvisory.footer.link.url">More Info</a>
-          </div>
-        </div>
-
         <!-- Card: Public Odor Complaints (with time widget inside expandable section) -->
         <div id="odor-complaints-card" class="card shadow expandable" onclick="selectCard('Odor Complaints')">
           <div class="card-header always-expand">
@@ -694,6 +640,70 @@
           <div class="card-footer">
             <span data-i18n="sidebar.cards.odorComplaints.footer.text"></span>
             <a target="_blank" href="https://example.com" data-i18n="sidebar.cards.odorComplaints.footer.link.text" data-i18n-href="sidebar.cards.odorComplaints.footer.link.url">More Info</a>
+          </div>
+        </div>
+
+        <!-- Card: Drinking Water Advisories (tap water) -->
+        <div id="water-advisory-card" class="card shadow expandable" onclick="selectCard('Drinking Water Advisories')">
+          <div class="card-header always-expand">
+            <i class="bi bi-droplet-half"></i>
+            <h3 class="card-title" data-i18n="sidebar.cards.waterAdvisory.title">Drinking Water (Tap Water)</h3>
+            <button class="expand-btn"><i class="bi bi-chevron-down"></i></button>
+          </div>
+
+          <div id="water-advisory-data-overview" class="card-data always-expand">
+            <table>
+              <tbody>
+                <tr>
+                  <td>
+                    <span class="indicator low"></span>
+                    <span id="water-advisory-count" data-i18n="sidebar.cards.waterAdvisory.overview.none">No active advisories</span>
+                    <br><span class="sublabel trend-flat" data-i18n="sidebar.cards.waterAdvisory.overview.scope">California American Water service area</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Shown only when a ?wateradvisory= demonstration advisory is on screen -->
+          <div id="water-advisory-demo" class="water-advisory-demo always-expand" hidden>
+            <i class="bi bi-cone-striped"></i>
+            <span data-i18n="sidebar.cards.waterAdvisory.demo.banner">Demonstration only — the advisory below is a made-up example, not a real notice.</span>
+          </div>
+
+          <!-- Shown only when an advisory is active in the region -->
+          <div id="water-advisory-alert" class="water-advisory-alert always-expand" hidden>
+            <div class="water-advisory-alert-header">
+              <i class="bi bi-exclamation-triangle-fill"></i>
+              <span class="water-advisory-alert-title"></span>
+            </div>
+            <p class="water-advisory-alert-body"></p>
+          </div>
+
+          <p data-i18n="sidebar.cards.waterAdvisory.p1">
+            Tap water delivered to homes in the region is treated and tested to meet state and federal drinking water standards. Sewage flows in the Tijuana River Valley affect beach and river water, not the treated water supplied to your tap.
+          </p>
+
+          <p>
+            <span data-i18n="sidebar.cards.waterAdvisory.p2.body">Your water utility issues an advisory when a main break, emergency repair, or planned work may affect your service or water quality. Check who supplies your water and look up current notices here:</span>
+            <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.waterAdvisory.p2.link.text" data-i18n-href="sidebar.cards.waterAdvisory.p2.link.url">California American Water Customer Advisories</a>
+          </p>
+
+          <p class="water-advisory-coverage" data-i18n="sidebar.cards.waterAdvisory.coverage">
+            Advisories shown here come from California American Water only. Other utilities serve parts of this region, so check with your own provider if you are unsure.
+          </p>
+
+          <div id="water-advisory-data" class="card-data" hidden>
+            <span data-i18n="sidebar.cards.waterAdvisory.tableLabel">Current advisories in the region</span>
+            <table>
+              <tbody>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="card-footer">
+            <span data-i18n="sidebar.cards.waterAdvisory.footer.text"></span>
+            <a target="_blank" href="https://example.com" data-i18n="sidebar.cards.waterAdvisory.footer.link.text" data-i18n-href="sidebar.cards.waterAdvisory.footer.link.url">More Info</a>
           </div>
         </div>
 

--- a/html_js/index.html
+++ b/html_js/index.html
@@ -108,6 +108,7 @@
       {label: 'Odor Complaints All', id: 'odor_3day_group' , layers: ['complaint-clusters-all','complaint-cluster-count-all','complaint-unclustered-all']}, // odor
       {label: 'Wastewater Spills', id: 'spill_group' , layers: ['spills']}, // water
       {label: 'Beach Status', id: 'beach_group' , layers: ['beaches', 'outfalls']}, // observations
+      {label: 'Drinking Water Advisories', id: 'water_advisory_group' , layers: ['water-advisory-fill','water-advisory-outline']}, // tap water
       {label: 'River Basin', id: 'water_group' , layers: ['basin','basin-outline', 'streams-line']},
 
     ]
@@ -133,55 +134,60 @@
       section.classList.toggle("expanded");
     }
 
-    // Toggle Layer Function for Top Pills
-    function toggleLayer(button, layer) {
-      if (undefined !== map) {
-        button.classList.toggle("active")
-        const buttonIcon = button.querySelector("i");
-        const buttonLegendIcon = button.querySelector("img");
-        let baseUrl;
-        let outlineUrl;
-        if (buttonLegendIcon) {
-          baseUrl = buttonLegendIcon.src.replace("-outline", "");
-          outlineUrl = baseUrl.replace(".svg", "-outline.svg");
-        }
-        console.log("Base url", baseUrl, "outline url", outlineUrl, "\n", buttonLegendIcon);
-
-        let visibility = 'none'
-        if (button.classList.contains("active")) {
-          console.log("toggled active: true");
-          visibility = 'visible'
-          buttonIcon.classList.add("bi-check-circle-fill");
-          buttonIcon.classList.remove("bi-x-circle");
-          if (buttonLegendIcon) buttonLegendIcon.src = baseUrl;
-        } else {
-          console.log("toggled active: false");
-          buttonIcon.classList.remove("bi-check-circle-fill");
-          buttonIcon.classList.add("bi-x-circle");
-          if (buttonLegendIcon) buttonLegendIcon.src = outlineUrl;
-        }
-
-        console.log("Toggled layer group:", layer);
-        const layerinfo = layerGroupInfo.find((l) => l.label === layer)
-        console.log("Toggled layer group:" + layer + " layerid:", layerinfo);
-        console.log("Toggled layer: groups", layerinfo.layers);
-        setGroupVisibility(map,layerinfo,visibility)
-      } else {
-        console.log("toggleLayer: no map object: ", layer);
+    // The single place a pill's appearance and its map layers are changed, so the
+    // two can never drift out of sync. `layer` is a layerGroupInfo label.
+    function setLayerActive(button, layer, active) {
+      if (undefined === map) {
+        console.log("setLayerActive: no map object: ", layer);
+        return;
       }
 
+      button.classList.toggle("active", active);
+
+      const buttonIcon = button.querySelector("i");
+      if (buttonIcon) {
+        buttonIcon.classList.toggle("bi-check-circle-fill", active);
+        buttonIcon.classList.toggle("bi-x-circle", !active);
+      }
+
+      const buttonLegendIcon = button.querySelector("img");
+      if (buttonLegendIcon) {
+        const baseUrl = buttonLegendIcon.src.replace("-outline", "");
+        buttonLegendIcon.src = active
+          ? baseUrl
+          : baseUrl.replace(".svg", "-outline.svg");
+      }
+
+      const layerinfo = layerGroupInfo.find((l) => l.label === layer)
+      if (!layerinfo) {
+        console.warn("setLayerActive: no layer group registered for:", layer);
+        return;
+      }
+      console.log("Set layer group:", layer, "active:", active, layerinfo.layers);
+      setGroupVisibility(map, layerinfo, active ? "visible" : "none")
+    }
+
+    // Toggle Layer Function for Top Pills
+    function toggleLayer(button, layer) {
+      setLayerActive(button, layer, !button.classList.contains("active"));
     }
 
 
-    // When a card is clicked, select the corresponding pill
+    // When a card is clicked, show its data on the map and light up the matching
+    // pill. Pills are matched on data-layer-group rather than their label text,
+    // which is translated and also carries a sublabel. Other layers are left
+    // alone so opening a card never hides data the user turned on.
     function selectCard(layer) {
-      var buttons = document.querySelectorAll("#top-bar button");
-      buttons.forEach(function (btn) {
-        btn.classList.remove("active");
-        if (btn.textContent.trim().toLowerCase() === layer.toLowerCase()) {
-          btn.classList.add("active");
-        }
-      });
+      const button = document.querySelector(
+        `#top-bar button[data-layer-group="${layer}"]`
+      );
+      if (!button) {
+        console.log("selectCard: no pill for layer:", layer);
+        return;
+      }
+      if (!button.classList.contains("active")) {
+        setLayerActive(button, layer, true);
+      }
       console.log("Selected card for layer:", layer);
     }
 
@@ -221,7 +227,7 @@
   <!-- Top Pill Container -->
   <div id="top-bar-container">
     <div id="top-bar">
-      <button id="beaches-filter-btn" class="active" onclick="toggleLayer(this, 'Beach Status')">
+      <button id="beaches-filter-btn" data-layer-group="Beach Status" class="active" onclick="toggleLayer(this, 'Beach Status')">
         <i class="bi bi-check-circle-fill"></i>
         <img src="img/marker-beach.svg">
         <div>
@@ -230,7 +236,7 @@
           <span class="trend-flat sublabel" data-i18n="topbar.currentData">current data</span>
         </div>
       </button>
-      <button id="h2s-filter-btn" class="active" onclick="toggleLayer(this, 'H₂S Levels')">
+      <button id="h2s-filter-btn" data-layer-group="H₂S Levels" class="active" onclick="toggleLayer(this, 'H₂S Levels')">
         <i class="bi bi-check-circle-fill"></i>
         <img src="img/marker-h2s.svg">
         <div>
@@ -239,7 +245,7 @@
           <span class="trend-flat sublabel" data-i18n="topbar.currentData">current data</span>
         </div>
       </button>
-      <button id="complaints-filter-btn" class="active" onclick="toggleLayer(this, 'Odor Complaints')">
+      <button id="complaints-filter-btn" data-layer-group="Odor Complaints" class="active" onclick="toggleLayer(this, 'Odor Complaints')">
         <i class="bi bi-check-circle-fill"></i>
         <img src="img/marker-complaint.svg">
         <div>
@@ -248,7 +254,15 @@
           <span class="trend-flat sublabel" data-i18n="topbar.prevComplaintdays"></span>
         </div>
       </button>
-      <button id="spills-filter-btn" class="active" onclick="toggleLayer(this, 'Wastewater Spills')">
+      <button id="water-advisory-filter-btn" data-layer-group="Drinking Water Advisories" class="active" onclick="toggleLayer(this, 'Drinking Water Advisories')">
+        <i class="bi bi-check-circle-fill"></i>
+        <div>
+          <span data-i18n="topbar.waterAdvisories">Drinking Water</span>
+          <br>
+          <span class="trend-flat sublabel" data-i18n="topbar.currentData">current data</span>
+        </div>
+      </button>
+      <button id="spills-filter-btn" data-layer-group="Wastewater Spills" class="active" onclick="toggleLayer(this, 'Wastewater Spills')">
         <i class="bi bi-check-circle-fill"></i>
         <img src="img/marker-spill.svg">
         <div>
@@ -257,7 +271,7 @@
           <span class="trend-flat sublabel" data-i18n="topbar.prevSpilldays"></span>
         </div>
       </button>
-<!--      <button id="river-filter-btn" class="" onclick="toggleLayer(this, 'River Basin')">-->
+<!--      <button id="river-filter-btn" data-layer-group="River Basin" class="" onclick="toggleLayer(this, 'River Basin')">-->
 <!--        <i class="bi bi-x-circle"></i>-->
 <!--        <span data-i18n="topbar.riverBasin">River Basin</span>-->
 <!--      </button>-->
@@ -521,7 +535,7 @@
         </div>
 
         <!-- Card: Beach Closures (with time widget inside expandable section) -->
-        <div id="beach-closures-card" class="card shadow expandable" onclick="selectCard('Beach Closures')">
+        <div id="beach-closures-card" class="card shadow expandable" onclick="selectCard('Beach Status')">
           <div class="card-header always-expand">
             <i class="bi bi-water"></i>
             <h3 class="card-title" data-i18n="sidebar.cards.beachClosures.title">Beach Closures</h3>
@@ -577,6 +591,64 @@
           </div>
         </div>
 
+        <!-- Card: Drinking Water Advisories (tap water) -->
+        <div id="water-advisory-card" class="card shadow expandable" onclick="selectCard('Drinking Water Advisories')">
+          <div class="card-header always-expand">
+            <i class="bi bi-droplet-half"></i>
+            <h3 class="card-title" data-i18n="sidebar.cards.waterAdvisory.title">Drinking Water (Tap Water)</h3>
+            <button class="expand-btn"><i class="bi bi-chevron-down"></i></button>
+          </div>
+
+          <div id="water-advisory-data-overview" class="card-data always-expand">
+            <table>
+              <tbody>
+                <tr>
+                  <td>
+                    <span class="indicator low"></span>
+                    <span id="water-advisory-count" data-i18n="sidebar.cards.waterAdvisory.overview.none">No active advisories</span>
+                    <br><span class="sublabel trend-flat" data-i18n="sidebar.cards.waterAdvisory.overview.scope">California American Water service area</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Shown only when an advisory is active in the region -->
+          <div id="water-advisory-alert" class="water-advisory-alert always-expand" hidden>
+            <div class="water-advisory-alert-header">
+              <i class="bi bi-exclamation-triangle-fill"></i>
+              <span class="water-advisory-alert-title"></span>
+            </div>
+            <p class="water-advisory-alert-body"></p>
+          </div>
+
+          <p data-i18n="sidebar.cards.waterAdvisory.p1">
+            Tap water delivered to homes in the region is treated and tested to meet state and federal drinking water standards. Sewage flows in the Tijuana River Valley affect beach and river water, not the treated water supplied to your tap.
+          </p>
+
+          <p>
+            <span data-i18n="sidebar.cards.waterAdvisory.p2.body">Your water utility issues an advisory when a main break, emergency repair, or planned work may affect your service or water quality. Check who supplies your water and look up current notices here:</span>
+            <a href="https://example.com" target="_blank" data-i18n="sidebar.cards.waterAdvisory.p2.link.text" data-i18n-href="sidebar.cards.waterAdvisory.p2.link.url">California American Water Customer Advisories</a>
+          </p>
+
+          <p class="water-advisory-coverage" data-i18n="sidebar.cards.waterAdvisory.coverage">
+            Advisories shown here come from California American Water only. Other utilities serve parts of this region, so check with your own provider if you are unsure.
+          </p>
+
+          <div id="water-advisory-data" class="card-data" hidden>
+            <span data-i18n="sidebar.cards.waterAdvisory.tableLabel">Current advisories in the region</span>
+            <table>
+              <tbody>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="card-footer">
+            <span data-i18n="sidebar.cards.waterAdvisory.footer.text"></span>
+            <a target="_blank" href="https://example.com" data-i18n="sidebar.cards.waterAdvisory.footer.link.text" data-i18n-href="sidebar.cards.waterAdvisory.footer.link.url">More Info</a>
+          </div>
+        </div>
+
         <!-- Card: Public Odor Complaints (with time widget inside expandable section) -->
         <div id="odor-complaints-card" class="card shadow expandable" onclick="selectCard('Odor Complaints')">
           <div class="card-header always-expand">
@@ -626,7 +698,7 @@
         </div>
 
         <!-- Card: Wastewater -->
-        <div id="wastewater-card" class="card shadow expandable" onclick="selectCard('Wastewater')">
+        <div id="wastewater-card" class="card shadow expandable" onclick="selectCard('Wastewater Spills')">
           <div class="card-header always-expand">
             <img src="img/marker-spill-outline.svg">
             <h3 class="card-title" data-i18n="sidebar.cards.wastewater.title">Public Wastewater Complaints</h3>
@@ -796,6 +868,14 @@
       <div class="legend-item">
         <img src="img/marker-beach.svg" alt="Beach Marker" />
         <span data-i18n="mapFooter.legend.beach">Beach</span>
+      </div>
+      <div class="legend-item">
+        <span class="legend-swatch water-advisory-emergency"></span>
+        <span data-i18n="mapFooter.legend.waterAdvisoryEmergency">Drinking water emergency advisory</span>
+      </div>
+      <div class="legend-item">
+        <span class="legend-swatch water-advisory-general"></span>
+        <span data-i18n="mapFooter.legend.waterAdvisoryGeneral">Drinking water notice</span>
       </div>
     </div>
 

--- a/html_js/js/app.js
+++ b/html_js/js/app.js
@@ -8,6 +8,25 @@ let latestH2SData = null;
 let latestOdorData = null;
 let latestBeachData = null;
 
+// --- Drinking Water Advisories (American Water) ---
+// Source of truth: the ArcGIS MapServer behind awgis.amwater.com/CustomerAdvisoryMap
+const amWaterAdvisoryBase =
+  "https://utility.arcgis.com/usrsvcs/servers/482bbe2135c54d178ec406189303faf4" +
+  "/rest/services/CustomerAdvisoryMap/DisplayData_SDE/MapServer";
+
+// Layer 17 is emergency advisories (main breaks, boil water notices, emergency
+// repairs), 16 is general notices (planned work). Layer 15 holds advisories that
+// have already been lifted, so it is not shown.
+const amWaterAdvisoryLayers = {
+  17: { level: "emergency", indicator: "high" },
+  16: { level: "general", indicator: "moderate" },
+};
+
+// South Bay / Tijuana River Valley area of interest [west, south, east, north].
+// Covers Imperial Beach, Coronado, San Ysidro, Nestor, Otay Mesa and south Chula
+// Vista. An advisory counts as "in the region" when its footprint overlaps this.
+const waterAdvisoryAoi = [-117.25, 32.5, -116.9, 32.68];
+
 // --- Date/Time Formatting Helpers ---
 function formatDateTime(date, options) {
   // Use i18next's detected language for formatting
@@ -441,6 +460,258 @@ function renderWastewaterFlows(data) {
 
 }
 
+// --- Drinking Water Advisory Rendering ---
+
+// Advisories arrive as one feature per polygon, so several features can share an
+// EventID. Merge them into one entry per event, keeping the combined footprint.
+function groupWaterAdvisories(geoData) {
+  const byEvent = new Map();
+
+  for (const feature of geoData.features) {
+    const props = feature.properties;
+    const key = `${props.advisoryLevel}|${props.EventID}`;
+    let advisory = byEvent.get(key);
+    if (!advisory) {
+      advisory = {
+        id: props.EventID,
+        level: props.advisoryLevel,
+        indicator: props.advisoryLevel === "emergency" ? "high" : "moderate",
+        type: props.EventType || "Advisory",
+        place: parseAdvisoryPlace(props),
+        start: props.EventStartDate || 0,
+        expires: props.EventExpirationDate || 0,
+        message: props.EventMessage || props.EventHeader || "",
+        link: props.EventHyperlink || "",
+        bbox: [180, 90, -180, -90],
+      };
+      byEvent.set(key, advisory);
+    }
+    growAdvisoryBbox(advisory.bbox, feature.geometry);
+  }
+
+  return [...byEvent.values()];
+}
+
+function growAdvisoryBbox(bbox, geometry) {
+  const walk = (coords) => {
+    if (Array.isArray(coords[0])) {
+      coords.forEach(walk);
+      return;
+    }
+    bbox[0] = Math.min(bbox[0], coords[0]);
+    bbox[1] = Math.min(bbox[1], coords[1]);
+    bbox[2] = Math.max(bbox[2], coords[0]);
+    bbox[3] = Math.max(bbox[3], coords[1]);
+  };
+  if (geometry) walk(geometry.coordinates);
+  return bbox;
+}
+
+// Bounding-box overlap against the area of interest. Coarser than a true polygon
+// intersection, but it errs toward showing an advisory rather than hiding one.
+function bboxOverlapsAoi(bbox) {
+  const [west, south, east, north] = bbox;
+  if (west > east) return false; // no geometry came back for this event
+  const [aoiWest, aoiSouth, aoiEast, aoiNorth] = waterAdvisoryAoi;
+  return (
+    west <= aoiEast &&
+    east >= aoiWest &&
+    south <= aoiNorth &&
+    north >= aoiSouth
+  );
+}
+
+// A boil order changes what residents should do with their tap, so it is called
+// out separately from other emergencies. "Lifted" types are the all-clear.
+function isBoilWaterAdvisory(advisory) {
+  return /boil/i.test(advisory.type) && !/lifted/i.test(advisory.type);
+}
+
+// The utility publishes event types in English only. Translate the ones the
+// service actually uses and fall back to the raw value for anything new.
+function translateAdvisoryType(type) {
+  if (!type) return "";
+  const key = `sidebar.cards.waterAdvisory.eventTypes.${type.replace(
+    /[^a-zA-Z0-9]/g,
+    ""
+  )}`;
+  return window.i18next.t(key, { defaultValue: type });
+}
+
+// "Imperial Beach: Main Break : This is an urgent..." -> "Imperial Beach"
+function parseAdvisoryPlace(props) {
+  const header = (props.EventHeader || "").trim();
+  const head = header.split(/\s*:\s*/)[0] || "";
+  return (head.split(",")[0] || "").trim() || `Event ${props.EventID}`;
+}
+
+// The service is queried statewide, so trim the map layer down to the footprints
+// that actually reach the region before handing them to Mapbox.
+function regionalAdvisoryFeatures(geoData) {
+  return {
+    type: "FeatureCollection",
+    features: geoData.features.filter((feature) =>
+      bboxOverlapsAoi(growAdvisoryBbox([180, 90, -180, -90], feature.geometry))
+    ),
+  };
+}
+
+function renderWaterAdvisory(geoData) {
+  window.latestWaterAdvisoryData = geoData;
+
+  const card = document.querySelector("#water-advisory-card");
+  if (!card) return;
+
+  const advisories = groupWaterAdvisories(geoData)
+    .filter((advisory) => bboxOverlapsAoi(advisory.bbox))
+    .sort((a, b) => {
+      // Boil orders first, then other emergencies, then most recently started.
+      const boilA = isBoilWaterAdvisory(a);
+      const boilB = isBoilWaterAdvisory(b);
+      if (boilA !== boilB) return boilA ? -1 : 1;
+      if (a.level !== b.level) return a.level === "emergency" ? -1 : 1;
+      return b.start - a.start;
+    });
+  console.log("[app.js] (Water) Advisories in the region:", advisories);
+
+  const hasBoilWater = advisories.some(isBoilWaterAdvisory);
+  const hasEmergency = advisories.some((a) => a.level === "emergency");
+
+  // Boil orders outrank everything else, since they tell residents to stop
+  // drinking the tap water.
+  const alertKind = hasBoilWater
+    ? "boilWater"
+    : hasEmergency
+    ? "emergency"
+    : "general";
+
+  // Push the matching footprints to the map, whether or not the map is ready yet.
+  window.latestWaterAdvisoryRegional = regionalAdvisoryFeatures(geoData);
+  if (typeof syncWaterAdvisoryLayer === "function") syncWaterAdvisoryLayer();
+
+  // Overview line
+  const countSpan = document.getElementById("water-advisory-count");
+  const countIndicator = countSpan?.parentElement.querySelector(".indicator");
+  if (countSpan && countIndicator) {
+    countSpan.innerText = advisories.length
+      ? i18next.t("sidebar.cards.waterAdvisory.overview.count", {
+          count: advisories.length,
+        })
+      : i18next.t("sidebar.cards.waterAdvisory.overview.none");
+    countIndicator.className =
+      "indicator " +
+      (advisories.length
+        ? alertKind === "general"
+          ? "moderate"
+          : "high"
+        : "low");
+  }
+
+  // Alert banner. Only shown when something is actually active in the region, and
+  // it opens the card so residents do not have to expand it to find the notice.
+  const alertElm = document.getElementById("water-advisory-alert");
+  if (alertElm) {
+    alertElm.hidden = advisories.length === 0;
+    if (advisories.length) {
+      // Keep always-expand so the alert stays visible even when the card is collapsed.
+      // Boil orders reuse the emergency styling.
+      alertElm.className = `water-advisory-alert always-expand ${
+        alertKind === "general" ? "general" : "emergency"
+      }`;
+      alertElm.querySelector(".water-advisory-alert-title").innerText =
+        i18next.t(`sidebar.cards.waterAdvisory.alert.${alertKind}Title`, {
+          count: advisories.length,
+        });
+      alertElm.querySelector(".water-advisory-alert-body").innerText = i18next.t(
+        `sidebar.cards.waterAdvisory.alert.${alertKind}Body`
+      );
+      card.classList.add("expanded");
+    }
+  }
+
+  // Detail table, one row per advisory in the region
+  const tableWrapper = document.getElementById("water-advisory-data");
+  const tbody = tableWrapper?.querySelector("tbody");
+  if (!tbody) return;
+  tbody.innerHTML = "";
+  tableWrapper.hidden = advisories.length === 0;
+
+  for (const advisory of advisories) {
+    const rowElm = document.createElement("tr");
+    rowElm.classList.add("card-data");
+    const placeCell = document.createElement("td");
+    const whenCell = document.createElement("td");
+    rowElm.appendChild(placeCell);
+    rowElm.appendChild(whenCell);
+    tbody.appendChild(rowElm);
+
+    const statusIndicator = document.createElement("span");
+    statusIndicator.className = `indicator ${advisory.indicator}`;
+    const placeElm = document.createElement("span");
+    placeElm.innerText = ` ${advisory.place}`;
+    placeCell.appendChild(statusIndicator);
+    placeCell.appendChild(placeElm);
+
+    const clockIcon = document.createElement("i");
+    clockIcon.className = "bi bi-clock";
+    const whenElm = document.createElement("span");
+    whenElm.innerText = ` ${translateAdvisoryType(
+      advisory.type
+    )} · ${formatDateTime(new Date(advisory.start), {
+      month: "short",
+      day: "numeric",
+    })}`;
+    whenCell.appendChild(clockIcon);
+    whenCell.appendChild(whenElm);
+
+    // Clicking a row frames the advisory footprint on the map.
+    rowElm.addEventListener("click", (event) => {
+      event.stopPropagation();
+      if (typeof zoomToWaterAdvisory === "function")
+        zoomToWaterAdvisory(advisory.bbox);
+    });
+
+    // The full utility message, so residents can read what the advisory says
+    // without leaving the dashboard.
+    if (advisory.message) {
+      const messageRow = document.createElement("tr");
+      const messageCell = document.createElement("td");
+      messageCell.colSpan = 2;
+      messageCell.className = "water-advisory-message";
+      const messageElm = document.createElement("span");
+      messageElm.innerText = advisory.message;
+      messageCell.appendChild(messageElm);
+      if (advisory.link) {
+        const linkElm = document.createElement("a");
+        linkElm.href = advisory.link;
+        linkElm.target = "_blank";
+        linkElm.rel = "noopener";
+        linkElm.innerText = i18next.t("sidebar.cards.waterAdvisory.noticeLink");
+        messageCell.appendChild(linkElm);
+      }
+      messageRow.appendChild(messageCell);
+      tbody.appendChild(messageRow);
+    }
+  }
+
+  // update card footer (using Intl)
+  const cardFooter = document.querySelector("#water-advisory-card .card-footer");
+  if (cardFooter) {
+    const span = cardFooter.querySelector("span");
+    const checkedDate = dayjs(geoData.lastUpdated).toDate();
+    const formattedDate = formatDateTime(checkedDate, {
+      month: "long",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    span.innerText = i18next.t("sidebar.cards.waterAdvisory.footer.text", {
+      date: formattedDate,
+    });
+  }
+}
+
 // --- Beach Closures Rendering ---
 function renderBeachClosures(jsonData) {
   latestBeachData = jsonData; // Store data
@@ -661,6 +932,52 @@ function fetchWastewaterData() {
     .catch((error) => {
       console.error("Error fetching Wastewater Flows JSON:", error);
       document.querySelector("#wastewater-flows-card").remove();
+    });
+}
+
+function fetchWaterAdvisoryLayer(id) {
+  const params = new URLSearchParams({
+    where: "EventState='CA'",
+    outFields:
+      "EventID,EventType,EventStatus,EventState,EventHeader,EventMessage," +
+      "EventStartDate,EventExpirationDate,EventLastUpdatedDate,EventHyperlink",
+    returnGeometry: "true",
+    outSR: "4326",
+    maxAllowableOffset: "0.0002", // degrees, because outSR is 4326
+    f: "geojson",
+  });
+
+  return fetch(`${amWaterAdvisoryBase}/${id}/query?${params}`)
+    .then((response) =>
+      response.ok ? response.json() : Promise.reject(response.statusText)
+    )
+    .then((geoData) => {
+      if (geoData.error) return Promise.reject(geoData.error.message);
+      // Tag each feature with its severity so the card and the map layer can both
+      // work from a single merged collection.
+      return (geoData.features || []).map((feature) => {
+        feature.properties.advisoryLevel = amWaterAdvisoryLayers[id].level;
+        return feature;
+      });
+    });
+}
+
+function fetchWaterAdvisoryData() {
+  Promise.all(
+    Object.keys(amWaterAdvisoryLayers).map((id) => fetchWaterAdvisoryLayer(id))
+  )
+    .then((collections) => {
+      // The service reports no feed-level timestamp, so record when we checked.
+      const geoData = {
+        type: "FeatureCollection",
+        lastUpdated: new Date().toISOString(),
+        features: collections.flat(),
+      };
+      renderWaterAdvisory(geoData);
+    })
+    .catch((error) => {
+      console.error("Error fetching Drinking Water Advisories:", error);
+      document.querySelector("#water-advisory-card")?.remove();
     });
 }
 

--- a/html_js/js/app.js
+++ b/html_js/js/app.js
@@ -27,6 +27,58 @@ const amWaterAdvisoryLayers = {
 // Vista. An advisory counts as "in the region" when its footprint overlaps this.
 const waterAdvisoryAoi = [-117.25, 32.5, -116.9, 32.68];
 
+// Demonstration advisories, shown only when the page is opened with a
+// ?wateradvisory= flag, so the card can be shown to the county while no real
+// advisory covers the region. Everything these produce is labelled as an example
+// in the card, the list and the map popup — a fabricated notice must never be
+// mistaken for a real one. Real advisories are still fetched and shown alongside.
+const waterAdvisoryDemoScenarios = {
+  boil: { level: "emergency", type: "Main Break / Boil Water Advisory" },
+  emergency: { level: "emergency", type: "Main Break" },
+  general: { level: "general", type: "Planned Work" },
+};
+
+// A plausible service-area footprint over Imperial Beach, inside the AOI.
+const waterAdvisoryDemoFootprint = [
+  [-117.132, 32.556],
+  [-117.092, 32.556],
+  [-117.092, 32.588],
+  [-117.132, 32.588],
+  [-117.132, 32.556],
+];
+
+function waterAdvisoryDemoFeatures() {
+  const requested = (window.water_advisory_demo || "").toLowerCase();
+  if (!requested || requested === "off" || requested === "false") return [];
+
+  // "?wateradvisory=demo" (or any unrecognised value) shows the boil water case,
+  // which is the one the county most needs to see.
+  const name = waterAdvisoryDemoScenarios[requested] ? requested : "boil";
+  const scenario = waterAdvisoryDemoScenarios[name];
+  const now = Date.now();
+
+  console.log("[app.js] (Water) DEMONSTRATION advisory active:", name);
+  return [
+    {
+      type: "Feature",
+      geometry: { type: "Polygon", coordinates: [waterAdvisoryDemoFootprint] },
+      properties: {
+        advisoryLevel: scenario.level,
+        isDemo: true,
+        EventID: `DEMO-${name.toUpperCase()}`,
+        EventType: scenario.type,
+        EventStatus: "Active",
+        EventState: "CA",
+        EventHeader: "Imperial Beach: Example advisory",
+        EventMessage: i18next.t("sidebar.cards.waterAdvisory.demo.message"),
+        EventStartDate: now - 3 * 60 * 60 * 1000,
+        EventExpirationDate: now + 24 * 60 * 60 * 1000,
+        EventHyperlink: "",
+      },
+    },
+  ];
+}
+
 // --- Date/Time Formatting Helpers ---
 function formatDateTime(date, options) {
   // Use i18next's detected language for formatting
@@ -482,6 +534,7 @@ function groupWaterAdvisories(geoData) {
         expires: props.EventExpirationDate || 0,
         message: props.EventMessage || props.EventHeader || "",
         link: props.EventHyperlink || "",
+        isDemo: !!props.isDemo,
         bbox: [180, 90, -180, -90],
       };
       byEvent.set(key, advisory);
@@ -589,6 +642,11 @@ function renderWaterAdvisory(geoData) {
   window.latestWaterAdvisoryRegional = regionalAdvisoryFeatures(geoData);
   if (typeof syncWaterAdvisoryLayer === "function") syncWaterAdvisoryLayer();
 
+  // Demonstration banner. Shown whenever any advisory on screen is fabricated, so
+  // the card can never be screenshotted and read as a real notice.
+  const demoElm = document.getElementById("water-advisory-demo");
+  if (demoElm) demoElm.hidden = !advisories.some((a) => a.isDemo);
+
   // Overview line
   const countSpan = document.getElementById("water-advisory-count");
   const countIndicator = countSpan?.parentElement.querySelector(".indicator");
@@ -651,6 +709,15 @@ function renderWaterAdvisory(geoData) {
     placeElm.innerText = ` ${advisory.place}`;
     placeCell.appendChild(statusIndicator);
     placeCell.appendChild(placeElm);
+
+    // Label the row itself, so a demo advisory reads as an example even in a
+    // screenshot that crops out the banner above.
+    if (advisory.isDemo) {
+      const demoTag = document.createElement("span");
+      demoTag.className = "water-advisory-demo-tag";
+      demoTag.innerText = i18next.t("sidebar.cards.waterAdvisory.demo.tag");
+      placeCell.appendChild(demoTag);
+    }
 
     const clockIcon = document.createElement("i");
     clockIcon.className = "bi bi-clock";
@@ -963,6 +1030,8 @@ function fetchWaterAdvisoryLayer(id) {
 }
 
 function fetchWaterAdvisoryData() {
+  const demoFeatures = waterAdvisoryDemoFeatures();
+
   Promise.all(
     Object.keys(amWaterAdvisoryLayers).map((id) => fetchWaterAdvisoryLayer(id))
   )
@@ -971,12 +1040,21 @@ function fetchWaterAdvisoryData() {
       const geoData = {
         type: "FeatureCollection",
         lastUpdated: new Date().toISOString(),
-        features: collections.flat(),
+        features: [...collections.flat(), ...demoFeatures],
       };
       renderWaterAdvisory(geoData);
     })
     .catch((error) => {
       console.error("Error fetching Drinking Water Advisories:", error);
+      // A demonstration should still work if the utility service is unreachable.
+      if (demoFeatures.length) {
+        renderWaterAdvisory({
+          type: "FeatureCollection",
+          lastUpdated: new Date().toISOString(),
+          features: demoFeatures,
+        });
+        return;
+      }
       document.querySelector("#water-advisory-card")?.remove();
     });
 }

--- a/html_js/js/language.js
+++ b/html_js/js/language.js
@@ -36,6 +36,7 @@ async function initializeI18next() {
   fetchOdorData();
   fetchWastewaterData();
   fetchBeachData();
+  fetchWaterAdvisoryData();
 
   // --- Optional: Language Switcher ---
   // (Keep existing language switcher code)
@@ -111,6 +112,10 @@ function updateContent() {
   if (typeof renderWastewaterFlows === "function" && window.latestWastewaterData) {
     console.log("[language.js] Re-rendering Wastewater Flows");
     renderWastewaterFlows(window.latestWastewaterData);
+  }
+  if (typeof renderWaterAdvisory === "function" && window.latestWaterAdvisoryData) {
+    console.log("[language.js] Re-rendering Drinking Water Advisories");
+    renderWaterAdvisory(window.latestWaterAdvisoryData);
   }
 
   // Close any tooltips

--- a/html_js/js/mbmap.js
+++ b/html_js/js/mbmap.js
@@ -869,6 +869,13 @@ function water_advisory_layer() {
             "tooltips.waterAdvisory.title"
           )}</span>
         </div>
+        ${
+          props.isDemo
+            ? `<div class="tooltip-line water-advisory-demo-line">${window.i18next.t(
+                "tooltips.waterAdvisory.demo"
+              )}</div>`
+            : ""
+        }
         <div class="tooltip-line tooltip-table">
           <span data-i18n="tooltips.waterAdvisory.location">${window.i18next.t(
             "tooltips.waterAdvisory.location"

--- a/html_js/js/mbmap.js
+++ b/html_js/js/mbmap.js
@@ -786,6 +786,149 @@ function h2s_layer() {
   }
 }
 
+// app.js fetches the advisories and the map loads its style independently, so
+// whichever finishes last pushes the data into the source.
+function syncWaterAdvisoryLayer() {
+  if (!map.getSource("water-advisories") || !window.latestWaterAdvisoryRegional)
+    return;
+  map.getSource("water-advisories").setData(window.latestWaterAdvisoryRegional);
+}
+
+function zoomToWaterAdvisory(bbox) {
+  const [west, south, east, north] = bbox;
+  if (west > east) return; // no geometry for this advisory
+  map.fitBounds(
+    [
+      [west, south],
+      [east, north],
+    ],
+    { padding: 60, maxZoom: 14, duration: 800 }
+  );
+}
+
+function water_advisory_layer() {
+  try {
+    const advisoryVisible = document
+      .querySelector("#water-advisory-filter-btn")
+      .classList.contains("active");
+
+    // Starts empty; syncWaterAdvisoryLayer fills it once app.js has the data.
+    map.addSource("water-advisories", {
+      type: "geojson",
+      data: { type: "FeatureCollection", features: [] },
+    });
+
+    const advisoryColor = [
+      "match",
+      ["get", "advisoryLevel"],
+      "emergency",
+      "#ed1c25",
+      "general",
+      "#f9a028",
+      /* default */ "#f9a028",
+    ];
+
+    map.addLayer({
+      id: "water-advisory-fill",
+      type: "fill",
+      source: "water-advisories",
+      layout: { visibility: advisoryVisible ? "visible" : "none" },
+      paint: {
+        "fill-color": advisoryColor,
+        "fill-opacity": 0.25,
+      },
+    });
+
+    map.addLayer({
+      id: "water-advisory-outline",
+      type: "line",
+      source: "water-advisories",
+      layout: { visibility: advisoryVisible ? "visible" : "none" },
+      paint: {
+        "line-color": advisoryColor,
+        "line-width": 1.5,
+      },
+    });
+
+    map.on("click", "water-advisory-fill", function (e) {
+      var feature = e.features[0];
+      var props = feature.properties;
+      const isBoilWater = isBoilWaterAdvisory({ type: props.EventType || "" });
+      const isEmergency = props.advisoryLevel === "emergency";
+      const indicatorClass = isEmergency || isBoilWater ? "high" : "moderate";
+      const place = parseAdvisoryPlace(props);
+      const start = dayjs(props.EventStartDate);
+      const expires = dayjs(props.EventExpirationDate);
+      const message = props.EventMessage || props.EventHeader || "";
+
+      var popupContent = `
+      <div class="tooltip">
+        <div class="tooltip-header">
+          <i class="bi bi-droplet-half"></i>
+          <span data-i18n="tooltips.waterAdvisory.title">${window.i18next.t(
+            "tooltips.waterAdvisory.title"
+          )}</span>
+        </div>
+        <div class="tooltip-line tooltip-table">
+          <span data-i18n="tooltips.waterAdvisory.location">${window.i18next.t(
+            "tooltips.waterAdvisory.location"
+          )}</span>
+          <span>${place}</span>
+        </div>
+        <div class="tooltip-line tooltip-table">
+          <span data-i18n="tooltips.waterAdvisory.type">${window.i18next.t(
+            "tooltips.waterAdvisory.type"
+          )}</span>
+          <span class="labelled-indicator"><span class="indicator ${indicatorClass}"></span><span>${translateAdvisoryType(
+        props.EventType
+      )}</span></span>
+        </div>
+        <div class="tooltip-line tooltip-table">
+          <span data-i18n="tooltips.waterAdvisory.date">${window.i18next.t(
+            "tooltips.waterAdvisory.date"
+          )}</span>
+          <span>${window.i18next.t("tooltips.waterAdvisory.duration", {
+            start: start.locale(window.i18next.language).format("MMM D"),
+            end: expires.locale(window.i18next.language).format("MMM D"),
+          })}</span>
+        </div>
+        <div class="tooltip-line water-advisory-note">
+          <span>${message}</span>
+        </div>
+        <div class="tooltip-footer">
+          ${
+            props.EventHyperlink
+              ? `<a target="_blank" rel="noopener" href="${props.EventHyperlink}">${window.i18next.t(
+                  "tooltips.waterAdvisory.footer.link.text"
+                )}</a>`
+              : `<span data-i18n="tooltips.waterAdvisory.footer.text">${window.i18next.t(
+                  "tooltips.waterAdvisory.footer.text"
+                )}</span>`
+          }
+        </div>
+      </div>`;
+
+      new mapboxgl.Popup({
+        className: "mapbox-tooltip water-advisory-tooltip",
+      })
+        .setLngLat(e.lngLat)
+        .setHTML(popupContent)
+        .addTo(map);
+    });
+
+    map.on("mouseenter", "water-advisory-fill", function () {
+      map.getCanvas().style.cursor = "pointer";
+    });
+    map.on("mouseleave", "water-advisory-fill", function () {
+      map.getCanvas().style.cursor = "";
+    });
+
+    syncWaterAdvisoryLayer();
+  } catch (e) {
+    console.log("error creating drinking water advisory map layers", e);
+  }
+}
+
 function watershed_layer() {
 
   try {
@@ -1054,6 +1197,8 @@ map.on("load", function () {
     .then(() => {
       // All icons have loaded, you can proceed to add your layers.
    //   watershed_layer();
+      // Added first so the advisory polygons sit beneath the point markers.
+      water_advisory_layer();
       spills_layer(window.spill_days);
       beach_layer();
       complaints_layer(window.complaint_days);

--- a/html_js/locales/en.json
+++ b/html_js/locales/en.json
@@ -183,6 +183,11 @@
                         "text": "",
                         "url": ""
                     }
+                },
+                "demo": {
+                    "banner": "Demonstration only — the advisory below is a made-up example, not a real notice.",
+                    "tag": "Example",
+                    "message": "EXAMPLE ADVISORY — THIS IS NOT A REAL NOTICE. This sample text shows how a California American Water advisory would appear here. In a real advisory, this is where the utility's instructions to residents would be shown, including how long the advisory is expected to last and who to contact."
                 }
             },
             "odorComplaints": {
@@ -355,7 +360,8 @@
                 "link": {
                     "text": "Read the full notice"
                 }
-            }
+            },
+            "demo": "Example advisory — not a real notice"
         },
         "h2s": {
             "title": "Hydrogen Sulfide Measurement",

--- a/html_js/locales/en.json
+++ b/html_js/locales/en.json
@@ -133,6 +133,58 @@
                     }
                 }
             },
+            "waterAdvisory": {
+                "title": "Drinking Water (Tap Water)",
+                "overview": {
+                    "none": "No active advisories",
+                    "count_one": "{{count}} Active Advisory",
+                    "count_other": "{{count}} Active Advisories",
+                    "scope": "California American Water service area"
+                },
+                "eventTypes": {
+                    "MainBreak": "Main break",
+                    "MainBreakBoilOrder": "Main break / boil order",
+                    "MainBreakBoilWaterAdvisory": "Main break / boil water advisory",
+                    "EmergencyRepairs": "Emergency repairs",
+                    "PlannedWork": "Planned work",
+                    "PlannedWorkBoilAdvisory": "Planned work / boil advisory",
+                    "PlannedWorkBoilOrder": "Planned work / boil order",
+                    "PlannedWorkComplete": "Planned work complete",
+                    "BoilOrderAdvisoryExtended": "Boil order extended",
+                    "LiftedBoilOrder": "Boil order lifted",
+                    "LiftedBoilAdvisory": "Boil advisory lifted",
+                    "HydrantFlushing": "Hydrant flushing",
+                    "ImportantNotice": "Important notice",
+                    "Investigation": "Investigation",
+                    "Conservation": "Conservation"
+                },
+                "alert": {
+                    "boilWaterTitle": "Boil water advisory in your area",
+                    "boilWaterBody": "California American Water has issued a boil water advisory affecting part of this region. Do not drink water from the tap without boiling it first, and follow the instructions in the notice below until the utility lifts the advisory.",
+                    "emergencyTitle": "Water advisory in your area",
+                    "emergencyBody": "California American Water has issued an emergency advisory affecting part of this region. Follow the instructions in the notice below, including any guidance to boil water or to stop using the tap.",
+                    "generalTitle": "Water notice in your area",
+                    "generalBody": "California American Water has posted a notice affecting part of this region. Your water service or pressure may be interrupted, and you may notice discolored water. Details are in the notice below."
+                },
+                "p1": "Tap water delivered to homes in the region is treated and tested to meet state and federal drinking water standards. Sewage flows in the Tijuana River Valley affect beach and river water, not the treated water supplied to your tap.",
+                "p2": {
+                    "body": "Your water utility issues an advisory when a main break, emergency repair, or planned work may affect your service or water quality. Check who supplies your water and look up current notices here:",
+                    "link": {
+                        "text": "California American Water Customer Advisories",
+                        "url": "https://awgis.amwater.com/CustomerAdvisoryMap/"
+                    }
+                },
+                "coverage": "Advisories shown here come from California American Water only. Other utilities serve parts of this region, so check with your own provider if you are unsure who supplies your water.",
+                "tableLabel": "Current advisories in the region:",
+                "noticeLink": "Read the full notice",
+                "footer": {
+                    "text": "Last checked on {{date}}",
+                    "link": {
+                        "text": "",
+                        "url": ""
+                    }
+                }
+            },
             "odorComplaints": {
                 "title": "Air Quality Complaints",
                 "overview": {
@@ -223,6 +275,7 @@
         "beaches": "Beach Water Quality",
         "h2sLevels": "H₂S Levels",
         "odorComplaints": "Air Quality Complaints",
+        "waterAdvisories": "Drinking Water",
         "wastewaterSpills": "Wastewater Flows",
         "riverBasin": "River Basin",
         "currentData": "current data",
@@ -240,7 +293,9 @@
             "complaint": "Air Quality Complaint",
             "h2s": "H2S reading",
             "outlet": "Outfall",
-            "beach": "Beach"
+            "beach": "Beach",
+            "waterAdvisoryEmergency": "Drinking water emergency advisory",
+            "waterAdvisoryGeneral": "Drinking water notice"
         }
     },
     "dateTimeFormats": {
@@ -286,6 +341,19 @@
                 "link": {
                     "text": "Wastewater Flow Data",
                     "url": "https://www.waterboards.ca.gov/sandiego/water_issues/programs/tijuana_river_valley_strategy/sewage_issue.html"
+                }
+            }
+        },
+        "waterAdvisory": {
+            "title": "Drinking Water Advisory",
+            "location": "location:",
+            "type": "type:",
+            "date": "date:",
+            "duration": "{{start}} - {{end}}",
+            "footer": {
+                "text": "Issued by California American Water.",
+                "link": {
+                    "text": "Read the full notice"
                 }
             }
         },

--- a/html_js/locales/es.json
+++ b/html_js/locales/es.json
@@ -183,6 +183,11 @@
                         "text": "",
                         "url": ""
                     }
+                },
+                "demo": {
+                    "banner": "Solo demostración — el aviso siguiente es un ejemplo inventado, no un aviso real.",
+                    "tag": "Ejemplo",
+                    "message": "AVISO DE EJEMPLO — ESTE NO ES UN AVISO REAL. Este texto de muestra indica cómo aparecería aquí un aviso de California American Water. En un aviso real, aquí se mostrarían las instrucciones de la compañía para los residentes, incluida la duración prevista del aviso y a quién contactar."
                 }
             },
             "odorComplaints": {
@@ -355,7 +360,8 @@
                 "link": {
                     "text": "Leer el aviso completo"
                 }
-            }
+            },
+            "demo": "Aviso de ejemplo — no es un aviso real"
         },
         "h2s": {
             "title": "Medición de Sulfuro de Hidrógeno",

--- a/html_js/locales/es.json
+++ b/html_js/locales/es.json
@@ -133,6 +133,58 @@
                     }
                 }
             },
+            "waterAdvisory": {
+                "title": "Agua Potable (Agua de la Llave)",
+                "overview": {
+                    "none": "No hay avisos activos",
+                    "count_one": "{{count}} Aviso Activo",
+                    "count_other": "{{count}} Avisos Activos",
+                    "scope": "Área de servicio de California American Water"
+                },
+                "eventTypes": {
+                    "MainBreak": "Ruptura de tubería principal",
+                    "MainBreakBoilOrder": "Ruptura de tubería principal / orden de hervir el agua",
+                    "MainBreakBoilWaterAdvisory": "Ruptura de tubería principal / aviso de hervir el agua",
+                    "EmergencyRepairs": "Reparaciones de emergencia",
+                    "PlannedWork": "Trabajo programado",
+                    "PlannedWorkBoilAdvisory": "Trabajo programado / aviso de hervir el agua",
+                    "PlannedWorkBoilOrder": "Trabajo programado / orden de hervir el agua",
+                    "PlannedWorkComplete": "Trabajo programado completado",
+                    "BoilOrderAdvisoryExtended": "Orden de hervir el agua extendida",
+                    "LiftedBoilOrder": "Orden de hervir el agua levantada",
+                    "LiftedBoilAdvisory": "Aviso de hervir el agua levantado",
+                    "HydrantFlushing": "Purga de hidrantes",
+                    "ImportantNotice": "Aviso importante",
+                    "Investigation": "Investigación",
+                    "Conservation": "Conservación"
+                },
+                "alert": {
+                    "boilWaterTitle": "Aviso de hervir el agua en su área",
+                    "boilWaterBody": "California American Water ha emitido un aviso de hervir el agua que afecta parte de esta región. No beba agua de la llave sin hervirla primero, y siga las instrucciones del aviso a continuación hasta que la compañía levante el aviso.",
+                    "emergencyTitle": "Aviso de agua en su área",
+                    "emergencyBody": "California American Water ha emitido un aviso de emergencia que afecta parte de esta región. Siga las instrucciones del aviso a continuación, incluida cualquier indicación de hervir el agua o de dejar de usar la llave.",
+                    "generalTitle": "Notificación de agua en su área",
+                    "generalBody": "California American Water ha publicado una notificación que afecta parte de esta región. Su servicio de agua o la presión pueden interrumpirse, y es posible que note el agua descolorida. Los detalles están en el aviso a continuación."
+                },
+                "p1": "El agua de la llave que llega a los hogares de la región es tratada y analizada para cumplir con las normas estatales y federales de agua potable. Los flujos de aguas negras en el Valle del Río Tijuana afectan el agua de las playas y del río, no el agua tratada que llega a su llave.",
+                "p2": {
+                    "body": "Su compañía de agua emite un aviso cuando la ruptura de una tubería principal, una reparación de emergencia o un trabajo programado puede afectar su servicio o la calidad del agua. Verifique quién le suministra el agua y consulte los avisos vigentes aquí:",
+                    "link": {
+                        "text": "Avisos al Cliente de California American Water",
+                        "url": "https://awgis.amwater.com/CustomerAdvisoryMap/"
+                    }
+                },
+                "coverage": "Los avisos que se muestran aquí provienen únicamente de California American Water. Otras compañías dan servicio a partes de esta región, así que consulte con su propio proveedor si no está seguro de quién le suministra el agua.",
+                "tableLabel": "Avisos vigentes en la región:",
+                "noticeLink": "Leer el aviso completo",
+                "footer": {
+                    "text": "Última consulta el {{date}}",
+                    "link": {
+                        "text": "",
+                        "url": ""
+                    }
+                }
+            },
             "odorComplaints": {
                 "title": "Quejas del aire",
                 "overview": {
@@ -162,7 +214,6 @@
                     }
                 }
             },
-
             "wastewater": {
                 "title": "Flujos de Aguas Residuales",
                 "overview": {
@@ -224,6 +275,7 @@
         "beaches": "Calidad del Agua de Playas",
         "h2sLevels": "Niveles de H₂S",
         "odorComplaints": "Quejas del aire",
+        "waterAdvisories": "Agua Potable",
         "wastewaterSpills": "Flujos de Aguas Negras",
         "riverBasin": "Cuenca del Río",
         "currentData": "datos actuales",
@@ -241,7 +293,9 @@
             "complaint": "Queja por olor",
             "h2s": "Lectura de H₂S",
             "outlet": "Punto de descarga",
-            "beach": "Playa"
+            "beach": "Playa",
+            "waterAdvisoryEmergency": "Aviso de emergencia de agua potable",
+            "waterAdvisoryGeneral": "Notificación de agua potable"
         }
     },
     "dateTimeFormats": {
@@ -287,6 +341,19 @@
                 "link": {
                     "text": "Datos de Flujo de Aguas Residuales",
                     "url": "https://www.waterboards.ca.gov/sandiego/water_issues/programs/tijuana_river_valley_strategy/sewage_issue.html"
+                }
+            }
+        },
+        "waterAdvisory": {
+            "title": "Aviso de Agua Potable",
+            "location": "ubicación:",
+            "type": "tipo:",
+            "date": "fecha:",
+            "duration": "{{start}} - {{end}}",
+            "footer": {
+                "text": "Emitido por California American Water.",
+                "link": {
+                    "text": "Leer el aviso completo"
                 }
             }
         },


### PR DESCRIPTION
Adds drinking water (tap water) advisories to the dashboard, so residents can see whether there is an advisory affecting their tap and what it says.

Data comes from the California American Water `CustomerAdvisoryMap` ArcGIS service — the emergency and general advisory layers. Lifted advisories are not shown. The service is queried directly from the browser (it sends permissive CORS headers and `cache-control: max-age=30`).

## What this adds

- **Sidebar card** with basic tap water information — placeholder copy, to be refined with the county. When an advisory covers the region the card adds an alert banner and lists each advisory with its type, dates and the full utility notice. Clicking a row frames that advisory on the map.
- **Boil water orders are their own alert level**, ranking above other emergencies, since they change what residents should actually do with their tap. The service publishes types such as `Main Break / Boil Order` and `Planned Work / Boil Advisory`.
- **Map layer** of advisory footprints (red = emergency, amber = general) drawn beneath the point markers, with a click popup and two legend swatches, plus a **Drinking Water filter pill**.
- **English and Spanish** throughout, including the event type names the utility only publishes in English (unknown types fall back to the raw value).

## Which advisories count as "in the region"

Advisories are matched by bounding box overlap against a South Bay / Tijuana River Valley area of interest (`waterAdvisoryAoi` in `app.js`), covering Imperial Beach, Coronado, San Ysidro, Nestor, Otay Mesa and south Chula Vista. Advisories elsewhere in California do not raise an alert here. Bounding box overlap is coarser than a true polygon intersection, deliberately erring toward showing an advisory rather than hiding one.

## Worth a reviewer's attention

**Cal-Am is only one of several utilities in this region.** Sweetwater Authority serves Chula Vista / National City and City of San Diego Public Utilities serves much of San Ysidro / Nestor. As built, a Sweetwater customer sees "No active advisories", which is true for Cal-Am but says nothing about their own water. The card is therefore scoped to Cal-Am in its title, subtitle and a note in the body, and is structured so more utilities can be added as extra sources. Flagging in case the county wants different wording.

## Also included: `selectCard` pill fix

`selectCard` stripped `.active` from every filter pill without touching the map, so clicking any card greyed out all pills while every layer stayed visible. Its re-selection was also dead code — it compared `btn.textContent` against strings like `'Beach Closures'`, but pills carry sublabel text and get translated, so the match never succeeded.

Pill state and layer visibility now go through a single `setLayerActive` helper so they cannot drift apart, and cards resolve their pill via a `data-layer-group` attribute instead of matching display text. Opening a card turns its layer on and leaves the other pills alone, so it never hides data the user deliberately enabled.

## Testing

Driven in a browser against the live service. Statewide the feed currently returns 10 active CA events and 0 in the region, so the card shows "No active advisories"; the alert paths were verified with injected data:

- Emergency, general and boil water banners, including a boil order correctly outranking a *newer* plain emergency.
- A Monterey advisory correctly excluded from the region.
- Alert stays visible when the card is collapsed.
- Map popup, row-click zoom, pill toggle in lockstep with layer visibility.
- Spanish rendering, and mobile at 390px with no horizontal overflow.
- Pill invariant (`.active` matches actual layer visibility) holds across card clicks and toggles.

Rebased onto `develop`; the locale conflicts were resolved by keeping develop's content and re-applying only the new keys — verified no develop keys were lost and en/es stay at key parity. Re-tested after the rebase, with no console errors.